### PR TITLE
Improve default security to from 58-bits to 72-bits

### DIFF
--- a/html/pp.html
+++ b/html/pp.html
@@ -46,8 +46,8 @@
             <select id="input-entropy" class="modified">
               <option>29 bits</option>
               <option>43 bits</option>
-              <option selected="selected">58 bits</option>
-              <option>72 bits</option>
+              <option>58 bits</option>
+              <option selected="selected">72 bits</option>
               <option>87 bits</option>
             </select>
           </div>


### PR DESCRIPTION
Best practice for offline password cracking security to have an entropy of at least 70-bits in the system when generating passwords. Consider the following clustered computing projects to prove this:

Bitcoin mining is currently calculating SHA-256 hashes at a pace of:

    * 8,072,925.27 TH/s or 8.073x10^18 hashes per second [0]
    * 62-bits per second
    * 74-bits per hour
    * 79-bits per day
    * 87-bits per year

distributed.net is searching for a 72-bit RC5 key at a sustained pace of:

    * 799,912,853,455 kps or 800 billion keys per second [1]
    * 39-bits per second
    * 51-bits per hour
    * 55-bits per day
    * 64-bits per year

A recent clustered password cracking project cracked 320 million SHA-1 password
hashes at a peak rate of:

    * 180 GHps or 180 billion hashes per second [2]
    * 37-bits per second
    * 49-bits per hour
    * 53-bits per day
    * 62-bits per year

0. https://blockchain.info/charts/hash-rate
1. https://stats.distributed.net/projects.php?project_id=8
2. https://cynosureprime.blogspot.com/2017/08/320-million-hashes-exposed.html

While I think it's fair to say that the password hashing speeds of Bitcoin are unrealistic for practical password cracking situations, the distributed.net and MDXfind/Hashcat scenarios with 25 GPUs are not.

As a result, it should be considered "best practice" to move password entropy into the 70-bit security margin to prevent professional password crackers from realistically exhausting 1/2 of the password space.